### PR TITLE
add base64 option to svg rollup plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,9 +46,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
-      "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
       "dev": true
     },
     "node_modules/@alloc/quick-lru": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -33,6 +33,6 @@ export default {
     json(),
     postcss(),
     external(),
-    svg()
+    svg({ base64: true })
   ]
 };


### PR DESCRIPTION
Wasn't really sure how to build the project for a release (besides just running every script I guess), so I haven't tested this yet.

But the reason the logo wasn't appearing was because the svg rollup option was returning the svg code instead of converting it to base64:
<img width="396" alt="Screenshot 2023-09-06 at 5 29 26 PM" src="https://github.com/orbis-education/shared-components/assets/70538368/91318ef1-d91d-4592-9d99-9b07d1a17c7a">

So I believe adding the base64 option should fix it.
