### PR TITLE
Hotfix alert space issues

### DIFF
--- a/lib/css/components/alertPopup.css
+++ b/lib/css/components/alertPopup.css
@@ -1,9 +1,15 @@
-.alert-container {
+.alert-messages-container {
   position: sticky;
   top: .5rem;
   left: 0;
   width: 100%;
+  height: 0;
+  overflow: visible;
   z-index: 5000;
+}
+
+.alert-container {
+  position: relative;
   margin-bottom: 1rem;
 }
 

--- a/lib/css/components/buttons.css
+++ b/lib/css/components/buttons.css
@@ -8,12 +8,15 @@
 button {
   font-family: var(--defaultFonts);
   display: inline-block;
-  cursor: pointer;
   border-radius: 4px;
   padding: 10px 12px;
   font-size: 1rem;
   font-weight: 700;
   line-height: 1;
+
+  &:not(.disabled, :disabled, .readonly) {
+    cursor: pointer;
+  }
 }
 
 .btn,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shared-components",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shared-components",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shared-components",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Contains common components that are available for use by all applications developed.",
   "author": "Orbis Education",
   "copyrightYear": "2025",


### PR DESCRIPTION
I fixed an issue where the alert popups would push the rest of the page down. This will require me to fix update the Messages.jsx component in a bunch of repos, so just a heads up there.
<img width="1266" alt="Screenshot 2025-06-18 at 10 06 59 AM" src="https://github.com/user-attachments/assets/e7fd6a16-7439-4dff-97b8-6f90fb0435e5" />


And then I fixed another issue where hovering over a disabled button was still showing the pointer cursor when it wasn't supposed to.